### PR TITLE
C++ version of `as.raster.magick-image`

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -45,6 +45,10 @@ magick_image_info <- function(input) {
     .Call('magick_magick_image_info', PACKAGE = 'magick', input)
 }
 
+magick_image_as_raster <- function(data) {
+    .Call('magick_magick_image_as_raster', PACKAGE = 'magick', data)
+}
+
 magick_image_length <- function(image) {
     .Call('magick_magick_image_length', PACKAGE = 'magick', image)
 }

--- a/R/base.R
+++ b/R/base.R
@@ -96,13 +96,9 @@
 #' @importFrom grDevices as.raster
 "as.raster.magick-image" <- function(image, ...){
   assert_image(image)
-  buf <- image[[1]]
-  magick_image_as_raster(buf)
+  magick_image_as_raster(image[[1]])
 }
 
-as_raster_cpp <- function( image, ... ){
-
-}
 
 #' @export
 #' @importFrom graphics plot

--- a/R/base.R
+++ b/R/base.R
@@ -96,8 +96,12 @@
 #' @importFrom grDevices as.raster
 "as.raster.magick-image" <- function(image, ...){
   assert_image(image)
-  buf <- image_info(image)[[1]]
+  buf <- image[[1]]
   magick_image_as_raster(buf)
+}
+
+as_raster_cpp <- function( image, ... ){
+
 }
 
 #' @export

--- a/R/base.R
+++ b/R/base.R
@@ -92,19 +92,12 @@
   invisible()
 }
 
-## apply is slow, can easily be optimized in c++.
 #' @export
 #' @importFrom grDevices as.raster
 "as.raster.magick-image" <- function(image, ...){
   assert_image(image)
-  info <- image_info(image)
-  buf <- image[[1]]
-  bitmap <- as.character(buf[1:3, , , drop = FALSE])
-  dim(bitmap) <- c(3, info$width, info$height)
-  alpha <- t(buf[4,,] == as.raw(0x00))
-  raster <- apply(bitmap, 3:2, function(z){paste0(c('#', z), collapse = "")})
-  raster[alpha] <- "transparent"
-  as.raster(raster)
+  buf <- image_info(image)[[1]]
+  magick_image_as_raster(buf)
 }
 
 #' @export

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -137,6 +137,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// magick_image_as_raster
+Rcpp::CharacterVector magick_image_as_raster(Rcpp::RawVector data);
+RcppExport SEXP magick_magick_image_as_raster(SEXP dataSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::RawVector >::type data(dataSEXP);
+    rcpp_result_gen = Rcpp::wrap(magick_image_as_raster(data));
+    return rcpp_result_gen;
+END_RCPP
+}
 // magick_image_length
 int magick_image_length(XPtrImage image);
 RcppExport SEXP magick_magick_image_length(SEXP imageSEXP) {

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -162,7 +162,7 @@ Rcpp::CharacterVector magick_image_as_raster( Rcpp::RawVector data ){
         buf[5] = sixteen[ blue >> 4 ] ;
         buf[6] = sixteen[ blue & 0x0F ] ;
 
-        out[k] = buf ;
+        out[k] = Rf_mkCharLen( buf.c_str(), 7) ;
 
       } else {
         out[k] = transparent ;

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -144,7 +144,7 @@ Rcpp::CharacterVector magick_image_as_raster( Rcpp::RawVector data ){
   static std::string sixteen( "0123456789abcdef" ) ;
   Rcpp::String transparent( "transparent" ) ;
 
-  Rcpp::CharacterMatrix out(w,h) ;
+  Rcpp::CharacterMatrix out(h,w) ;
   Rbyte* p = data.begin() ;
   std::string buf( "#000000" ) ;
 

--- a/src/attributes.cpp
+++ b/src/attributes.cpp
@@ -136,3 +136,42 @@ Rcpp::DataFrame magick_image_info( XPtrImage input){
     Rcpp::_["stringsAsFactors"] = false
   );
 }
+
+// [[Rcpp::export]]
+Rcpp::CharacterVector magick_image_as_raster( Rcpp::RawVector data ){
+  Rcpp::IntegerVector dim = data.attr("dim") ;
+  int w = dim[1], h = dim[2] ;
+  static std::string sixteen( "0123456789abcdef" ) ;
+  Rcpp::String transparent( "transparent" ) ;
+
+  Rcpp::CharacterMatrix out(w,h) ;
+  Rbyte* p = data.begin() ;
+  std::string buf( "#000000" ) ;
+
+  for(int i=0; i<h; i++){
+    int k = i*w ;
+    for(int j=0; j<w; j++, p+= 4, k++){
+
+      if( p[3] ){
+        Rbyte red = p[0], green = p[1], blue = p[2] ;
+
+        buf[1] = sixteen[ red >> 4 ] ;
+        buf[2] = sixteen[ red & 0x0F ] ;
+        buf[3] = sixteen[ green >> 4 ] ;
+        buf[4] = sixteen[ green & 0x0F ] ;
+        buf[5] = sixteen[ blue >> 4 ] ;
+        buf[6] = sixteen[ blue & 0x0F ] ;
+
+        out[k] = buf ;
+
+      } else {
+        out[k] = transparent ;
+      }
+
+    }
+  }
+
+  out.attr("class") = "raster" ;
+  return out ;
+
+}


### PR DESCRIPTION
Because this comment was too tempting: 

```R
## apply is slow, can easily be optimized in c++.
```

This is just a serial C++ version. I get: 

```
> R <- old_as.raster(im)
> cpp <- as.raster(im)
> identical( R, cpp) 
[1] TRUE
> microbenchmark( cpp = as.raster(im), r = old_as.raster(im), times = 5 )
Unit: milliseconds
 expr        min         lq       mean     median         uq        max neval
  cpp   121.3381   121.6021   125.3086   123.7407   129.7754   130.0867     5
    r 11333.9366 11381.0601 11747.2822 11398.1421 12216.4571 12406.8148     5
```




