### PR TITLE
Write images to supporting _files dir when printing in rmarkdown

### DIFF
--- a/R/base.R
+++ b/R/base.R
@@ -112,8 +112,14 @@
   if(!length(x))
     return(invisible())
   ext <- ifelse(all(tolower(image_info(x)$format) == "gif"), "gif", "png")
-  tmp <- tempfile(fileext = paste0(".", ext))
-  image_write(x, path = tmp, format = ext)
+  fig.cur <- knitr:::plot_counter()
+  tmp <- knitr::fig_path(ext, number = fig.cur)
+  knitr:::in_base_dir({
+    if (!file_test("-d", dirname(tmp))) {
+      dir.create(dirname(tmp), recursive = TRUE)
+    }
+    image_write(x, path = tmp, format = ext)
+  })
   knitr::include_graphics(tmp)
 }
 


### PR DESCRIPTION
This PR addresses where images are stored when knitting an RMarkdown document #108.

I used [`knitr::wrap.recordedplot`](https://github.com/yihui/knitr/blob/7386aa3960e8126f8accaa35341b578b7af44277/R/output.R#L539-L558) to figure out the mechanics to make this work.

The changes I made use `knitr:::plot_counter()` to get the current figure number for the chunk. Then `knitr::fig_path()` gives the figure path for the image, relative to the base directory. Then, inside the document's base directory -- using `knitr:::in_base_dir()` -- we check that the directory exists and write out the image. Finally, we write out the relative link to the image as before with `knit::include_graphics()`.

I've tested with [a modified version of the README.Rmd](https://gist.github.com/gadenbuie/6d33e0dab5f5c93b38ea45e353048372) and I'm fairly confident that everything works as expected. I tested with `output: github_document`, `output: html_document` and `output: md_document`.

Some thoughts/notes:

1. We can have `knit_print` obey the [`fig.show`](https://yihui.name/knitr/options/#plots) flag by checking `knitr::opts_chunk$get("fig.show")`. I started to work on this and realized that it's easy for `fig.show="hide"` but might be more complicated when `fig.show` is `"animate"` or `"hold"`; so maybe this isn't something you'd want to include.

2. It seems that knitr holds plots until after rending other chunk outputs, so the ordering of figure numbers might not match their order in the code chunk. This doesn't affect presentation as the correct files are still matched in the markdown source.

3. This doesn't solve #102 as I think that relies on the methods of `print` rather than `knit_print`.

### Example

Input: `test_108.Rmd`

````
```{r plot-demo}
library(magick)
ggplot2::qplot(factor(cyl), data = mtcars, fill = factor(gear))

# Produce graphic
fig <- image_graph(width = 800, height = 600, res = 96)
ggplot2::qplot(factor(cyl), data = mtcars, fill = factor(gear))
invisible(dev.off())

fig
```
````

Output

```
    library(magick)
    ggplot2::qplot(factor(cyl), data = mtcars, fill = factor(gear))

![](test_108_files/figure-markdown_strict/plot-demo-2.png)

    # Produce graphic
    fig <- image_graph(width = 800, height = 600, res = 96)
    ggplot2::qplot(factor(cyl), data = mtcars, fill = factor(gear))
    invisible(dev.off())

    fig

![](test_108_files/figure-markdown_strict/plot-demo-1.png)
```