### PR TITLE
Render README.Rmd to GitHub Markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,3 @@ inst/doc/*.html
 src/Makevars
 windows
 !img/*
-README.md

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,3 +1,7 @@
+---
+output: github_document
+---
+
 # magick ![](http://www.textfiles.com/underconstruction/HeHeartlandPark2601underconstructionbar9.gif)
 
 ##### *Advanced Image-Processing in R*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,171 @@
+
+# magick ![](http://www.textfiles.com/underconstruction/HeHeartlandPark2601underconstructionbar9.gif)
+
+##### *Advanced Image-Processing in R*
+
+[![Project Status: Active – The project has reached a stable, usable
+state and is being actively
+developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
+[![Build
+Status](https://travis-ci.org/ropensci/magick.svg?branch=master)](https://travis-ci.org/ropensci/magick)
+[![AppVeyor Build
+Status](https://ci.appveyor.com/api/projects/status/github/ropensci/magick?branch=master&svg=true)](https://ci.appveyor.com/project/jeroen/magick)
+[![Coverage
+Status](https://codecov.io/github/ropensci/magick/coverage.svg?branch=master)](https://codecov.io/github/ropensci/magick?branch=master)
+[![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/magick)](https://cran.r-project.org/package=magick)
+[![CRAN RStudio mirror
+downloads](http://cranlogs.r-pkg.org/badges/magick)](https://cran.r-project.org/package=magick)
+[![Github
+Stars](https://img.shields.io/github/stars/ropensci/magick.svg?style=social&label=Github)](https://github.com/ropensci/magick)
+
+> Bindings to ImageMagick: the most comprehensive open-source image
+> processing library available. Supports many common formats (png, jpeg,
+> tiff, pdf, etc) and manipulations (rotate, scale, crop, trim, flip,
+> blur, etc). All operations are vectorized via the Magick++ STL meaning
+> they operate either on a single frame or a series of frames for
+> working with layers, collages, or animation. In RStudio images are
+> automatically previewed when printed to the console, resulting in an
+> interactive editing environment.
+
+## Documentation
+
+About the R package:
+
+  - [vignette: The magick package: Advanced Image-Processing in
+    R](https://cran.r-project.org/web/packages/magick/vignettes/intro.html)
+  - [rOpenSci Community Call
+    (recording)](https://vimeo.com/channels/rocommunitycalls/180799058)
+
+About the underlying library:
+
+  - [Magick++
+    Tutorial](https://www.imagemagick.org/Magick++/tutorial/Magick++_tutorial.pdf)
+  - [Magick++ STL
+    Documentation](https://www.imagemagick.org/Magick++/STL.html)
+
+## Hello World
+
+**Run examples in RStudio** to see live previews of the images\! If you
+do not use RStudio, use `image_browse` to open images. On Linux you can
+also use `image_display` to get an X11 preview.
+
+``` r
+library(magick)
+frink <- image_read("https://jeroen.github.io/images/frink.png")
+image_trim(frink)
+image_scale(frink, "200x200")
+image_flip(frink)
+image_rotate(frink, 45) ## <-- result of this is shown
+image_negate(frink)
+frink %>% 
+  image_background("green") %>% 
+  image_flatten() %>%
+  image_border("red", "10x10")
+```
+
+![](img/frink-rotated.png)
+
+Effects
+
+``` r
+image_oilpaint(frink)
+image_implode(frink)
+image_charcoal(frink) ## <-- result of this is shown
+image_blur(frink)
+image_edge(frink)
+```
+
+![](img/frink-charcoal.png)
+
+Create GIF animation:
+
+``` r
+# Download images
+oldlogo <- image_read("https://developer.r-project.org/Logo/Rlogo-2.png")
+newlogo <- image_read("https://www.r-project.org/logo/Rlogo.png")
+logos <- c(oldlogo, newlogo)
+logos <- image_scale(logos, "400x400")
+
+# Create GIF
+(animation1 <- image_animate(logos))
+image_write(animation1, "img/anim1.gif")
+
+# Morph effect  <-- result of this is shown
+(animation2 <- image_animate(image_morph(logos, frames = 10)))
+image_write(animation2, "img/anim2.gif")
+```
+
+![](img/anim2.gif)
+
+Read GIF anination frames. See the [rotating earth example
+GIF](https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif).
+
+``` r
+earth <- image_read("https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif")
+length(earth)
+earth[1]
+earth[1:3]
+earth1 <- rev(image_flip(earth)) ## How Austrialans see earth
+image_write(earth1, "img/earth1.gif") ## <-- result of this is shown
+```
+
+![](img/earth1.gif)
+
+R logo with dancing banana
+
+``` r
+logo <- image_read("https://www.r-project.org/logo/Rlogo.png")
+banana <- image_read("https://jeroen.github.io/images/banana.gif")
+front <- image_scale(banana, "300")
+background <- image_scale(logo, "400")
+frames <- lapply(as.list(front), function(x) image_flatten(c(background, x)))
+image_write(image_animate(image_join(frames)), "img/Rlogo-banana.gif")
+```
+
+![](img/Rlogo-banana.gif)
+
+## Installation
+
+Binary packages for **macOS** or **Windows** can be installed directly
+from CRAN:
+
+``` r
+install.packages("magick")
+```
+
+Installation from source on Linux or OSX requires the imagemagick
+[`Magick++`](https://www.imagemagick.org/Magick++/Documentation.html)
+library. On **Debian or Ubuntu** install
+[libmagick++-dev](https://packages.debian.org/testing/libmagick++-dev):
+
+    sudo apt-get install -y libmagick++-dev
+
+If you are on **Ubuntu** 14.04 (trusty) or 16.04 (xenial) you can get a
+more recent backport from the ppa:
+
+    sudo add-apt-repository -y ppa:opencpu/imagemagick
+    sudo apt-get update
+    sudo apt-get install -y libmagick++-dev 
+
+On **Fedora**, **CentOS or RHEL** we need
+[ImageMagick-c++-devel](https://apps.fedoraproject.org/packages/ImageMagick-c++-devel).
+However on CentOS the system version of ImageMagick is quite old. More
+recent versions are available from the [ImageMagick
+downloads](https://www.imagemagick.org/download/linux/CentOS/x86_64/)
+website.
+
+    sudo yum install ImageMagick-c++-devel
+
+On **macOS** use
+[imagemagick@6](https://github.com/Homebrew/homebrew-core/blob/master/Formula/imagemagick@6.rb)
+from Homebrew. Note that we need to build `--with-fontconfig` to support
+text features such as annotation and svg rendering.
+
+    brew reinstall imagemagick@6 --with-fontconfig --with-librsvg 
+    brew link --force imagemagick@6
+
+There is also a fork of imagemagick called graphicsmagick, but it
+doesn’t work as well. I highly recommend you build with
+imagemagick.
+
+[![](http://www.ropensci.org/public_images/github_footer.png)](http://ropensci.org)


### PR DESCRIPTION
GitHub no longer renders Rmd files as markdown: https://yihui.name/en/2018/10/rmd-github/

This PR removes `README.md` from `.gitignore` and adds a minimal YAML header to `README.Rmd` to render the `Rmd` file to GitHub-flavored markdown.