### PR TITLE
add support for literal svg

### DIFF
--- a/R/edit.R
+++ b/R/edit.R
@@ -13,8 +13,8 @@
 #'
 #' For reading svg or pdf it is recommended to use `image_read_svg()` and `image_read_pdf()`
 #' if the [rsvg][rsvg::rsvg] and [pdftools][pdftools::pdf_render_page] R packages are available.
-#' These functions provide more rendering options and better quality than built-in svg/pdf
-#' rendering delegates from imagemagick itself.
+#' These functions provide more rendering options (including rendering of literal svg) and
+#' better quality than built-in svg/pdf rendering delegates from imagemagick itself.
 #'
 #' X11 is required for `image_display()` which is only works on some platforms. A more
 #' portable method is `image_browse()` which opens the image in a browser. RStudio has
@@ -95,9 +95,12 @@ For better results use image_read_svg() which uses the rsvg package.", call. = F
 #' @rdname editing
 #' @examples if(require(rsvg))
 #' tiger <- image_read_svg("http://jeroen.github.io/images/tiger.svg")
+#' if(require(fontawesome) & require(rsvg))
+#' r_logo <- image_read_svg(fontawesome::fa("r-project", fill="steelblue"))
 image_read_svg <- function(path, width = NULL, height = NULL){
   path <- vapply(path, replace_url, character(1))
   images <- lapply(path, function(x){
+    if(is_svg(x)) x <- charToRaw(x)
     bitmap <- rsvg::rsvg_raw(x, width = width, height = height)
     magick_image_readbitmap_raw(bitmap)
   })

--- a/R/edit.R
+++ b/R/edit.R
@@ -95,8 +95,12 @@ For better results use image_read_svg() which uses the rsvg package.", call. = F
 #' @rdname editing
 #' @examples if(require(rsvg))
 #' tiger <- image_read_svg("http://jeroen.github.io/images/tiger.svg")
-#' if(require(fontawesome) & require(rsvg))
-#' r_logo <- image_read_svg(fontawesome::fa("r-project", fill="steelblue"))
+#' svgtxt <- '<?xml version="1.0" encoding="UTF-8"?>
+#' <svg width="400" height="400" viewBox="0 0 400 400" fill="none">
+#'  <circle fill="steelblue" cx="200" cy="200" r="100" />
+#'  <circle fill="yellow" cx="200" cy="200" r="90" />
+#' </svg>'
+#' circles <- image_read_svg(svgtxt)
 image_read_svg <- function(path, width = NULL, height = NULL){
   path <- vapply(path, replace_url, character(1))
   images <- lapply(path, function(x){

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,7 +18,7 @@ read_path <- function(path){
 }
 
 is_url <- function(path){
-  grepl("https?://", path)
+  grepl("^https?://", path)
 }
 
 is_svg <- function(path){

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,7 +21,14 @@ is_url <- function(path){
   grepl("https?://", path)
 }
 
+is_svg <- function(path){
+  # svg files ending in "</svg>" with or without whitespace following it
+  grepl("<\\/svg>\\s?$", path)
+}
+
 replace_url <- function(path){
+  if(is_svg(path))
+    return(path)
   if(is_url(path)){
     pattern <- "\\[[-,0-9]+\\]$"
     suffix <- regmatches(path, regexpr(pattern, path))

--- a/man/editing.Rd
+++ b/man/editing.Rd
@@ -182,8 +182,12 @@ if(require(webp)) image_read(webp::read_webp("example.webp"))
 unlink(c("example.webp", "output.png"))
 if(require(rsvg))
 tiger <- image_read_svg("http://jeroen.github.io/images/tiger.svg")
-if(require(fontawesome) & require(rsvg))
-r_logo <- image_read_svg(fontawesome::fa("r-project", fill="steelblue"))
+svgtxt <- '<?xml version="1.0" encoding="UTF-8"?>
+<svg width="400" height="400" viewBox="0 0 400 400" fill="none">
+ <circle fill="steelblue" cx="200" cy="200" r="100" />
+ <circle fill="yellow" cx="200" cy="200" r="90" />
+</svg>'
+circles <- image_read_svg(svgtxt)
 if(require(pdftools))
 image_read_pdf(file.path(R.home('doc'), 'NEWS.pdf'), pages = 1, density = 100)
 # create a solid canvas

--- a/man/editing.Rd
+++ b/man/editing.Rd
@@ -146,8 +146,8 @@ a single frame as a raw bitmap matrix with pixel values.
 
 For reading svg or pdf it is recommended to use \code{image_read_svg()} and \code{image_read_pdf()}
 if the \link[rsvg:rsvg]{rsvg} and \link[pdftools:pdf_render_page]{pdftools} R packages are available.
-These functions provide more rendering options and better quality than built-in svg/pdf
-rendering delegates from imagemagick itself.
+These functions provide more rendering options (including rendering of literal svg) and
+better quality than built-in svg/pdf rendering delegates from imagemagick itself.
 
 X11 is required for \code{image_display()} which is only works on some platforms. A more
 portable method is \code{image_browse()} which opens the image in a browser. RStudio has
@@ -182,6 +182,8 @@ if(require(webp)) image_read(webp::read_webp("example.webp"))
 unlink(c("example.webp", "output.png"))
 if(require(rsvg))
 tiger <- image_read_svg("http://jeroen.github.io/images/tiger.svg")
+if(require(fontawesome) & require(rsvg))
+r_logo <- image_read_svg(fontawesome::fa("r-project", fill="steelblue"))
 if(require(pdftools))
 image_read_pdf(file.path(R.home('doc'), 'NEWS.pdf'), pages = 1, density = 100)
 # create a solid canvas


### PR DESCRIPTION
Closes #231 adding support for literal svg.
I did not add unit test, only an example with `fontawesome`, but this code runs now, i.e. it can be reused for unit test, if you want.
```r
library(magick)
im_path <- "https://upload.wikimedia.org/wikipedia/commons/9/9a/ImageMagick_logo.svg"
im_logo <- readr::read_file(im_path)
r_logo <- fontawesome::fa('r-project', fill = "steelblue")
image_read_svg(im_logo)
image_read_svg(r_logo)
image_read_svg(list(im_logo, r_logo))
```