### PR TITLE
Implement defines for image_write

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,6 @@ Suggests:
     tesseract (>= 2.0),
     gifski
 Encoding: UTF-8
-RoxygenNote: 7.1.0.9000
+RoxygenNote: 7.1.1
 Roxygen: list(load = "installed", markdown = TRUE)
 Language: en-US

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+2.4.0.9000
+  - Add 'defines' parameter to image_write
+
 2.4.0
   - New functions: image_fx_sequence, image_deskew_angle, image_get_artifacts
   - Add 'defines' parameter to image_read and image_blank

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -313,8 +313,8 @@ magick_image_read_list <- function(list) {
     .Call('_magick_magick_image_read_list', PACKAGE = 'magick', list)
 }
 
-magick_image_write <- function(input, format, quality, depth, density, comment) {
-    .Call('_magick_magick_image_write', PACKAGE = 'magick', input, format, quality, depth, density, comment)
+magick_image_write <- function(input, format, quality, depth, density, comment, defines) {
+    .Call('_magick_magick_image_write', PACKAGE = 'magick', input, format, quality, depth, density, comment, defines)
 }
 
 magick_image_write_frame <- function(input, format, i = 1L) {

--- a/R/edit.R
+++ b/R/edit.R
@@ -382,12 +382,20 @@ demo_image <- function(path){
 
 validate_defines <- function(defines){
   if(length(defines)){
-    if(!is.character(defines))
-      stop("Argumet 'defines' must be named character vector")
-    if(length(unique(names(defines))) != length(defines))
+    if (is.list(defines)) {
+      for (x in defines) {
+        if (!is.character(x) && !is.logical(x) || length(x) != 1) {
+          stop("Argument 'defines' must be a logical vector, character vector, or named list of length-1 character and logical vectors")
+        }
+      }
+    } else if (!is.character(x) && !is.logical(x)) {
+      stop("Argument 'defines' must be a logical vector, character vector, or named list of length-1 character and logical vectors")
+    }
+    if(length(unique(names(defines))) != length(defines) || '' %in% names(defines))
       stop("Argument 'defines' does not have proper names")
-    return(defines)
+    return(as.list(defines))
   } else {
-    return(character())
+    # Empty named list
+    return(setNames(list(), character(0)))
   }
 }

--- a/R/edit.R
+++ b/R/edit.R
@@ -210,7 +210,8 @@ convert_EBImage <- function(x){
 #' @param quality number between 0 and 100 for jpeg quality. Defaults to 75.
 #' @param comment text string added to the image metadata for supported formats
 image_write <- function(image, path = NULL, format = NULL, quality = NULL,
-                        depth = NULL, density = NULL, comment = NULL, flatten = FALSE){
+                        depth = NULL, density = NULL, comment = NULL,
+                        flatten = FALSE, defines = NULL) {
   assert_image(image)
   if(!length(image))
     warning("Writing image with 0 frames")
@@ -221,7 +222,8 @@ image_write <- function(image, path = NULL, format = NULL, quality = NULL,
   depth <- as.integer(depth)
   density <- as.character(density)
   comment <- as.character(comment)
-  buf <- magick_image_write(image, format, quality, depth, density, comment)
+  defines <- validate_defines(defines)
+  buf <- magick_image_write(image, format, quality, depth, density, comment, defines)
   if(is.character(path)){
     writeBin(buf, path)
     return(invisible(path))

--- a/man/editing.Rd
+++ b/man/editing.Rd
@@ -122,7 +122,7 @@ depending on the image}
 
 \item{frame}{integer setting which frame to extract from the image}
 
-\item{tidy}{converts raster data to long form for use with \link[ggplot2:geom_tile]{geom_raster}.
+\item{tidy}{converts raster data to long form for use with \link[ggplot2:geom_raster]{geom_raster}.
 If \code{FALSE} output is the same as \code{as.raster()}.}
 
 \item{animate}{support animations in the X11 display}

--- a/man/editing.Rd
+++ b/man/editing.Rd
@@ -37,7 +37,8 @@ image_write(
   depth = NULL,
   density = NULL,
   comment = NULL,
-  flatten = FALSE
+  flatten = FALSE,
+  defines = NULL
 )
 
 image_convert(

--- a/man/editing.Rd
+++ b/man/editing.Rd
@@ -123,7 +123,7 @@ depending on the image}
 
 \item{frame}{integer setting which frame to extract from the image}
 
-\item{tidy}{converts raster data to long form for use with \link[ggplot2:geom_raster]{geom_raster}.
+\item{tidy}{converts raster data to long form for use with \link[ggplot2:geom_tile]{geom_raster}.
 If \code{FALSE} output is the same as \code{as.raster()}.}
 
 \item{animate}{support animations in the X11 display}

--- a/man/ocr.Rd
+++ b/man/ocr.Rd
@@ -14,7 +14,7 @@ image_ocr_data(image, language = "eng", ...)
 \item{image}{magick image object returned by \code{\link[=image_read]{image_read()}} or \code{\link[=image_graph]{image_graph()}}}
 
 \item{language}{passed to \link[tesseract:tesseract]{tesseract}. To install additional languages see
-instructions in \link[tesseract:tessdata]{tesseract_download()}.}
+instructions in \link[tesseract:tesseract_download]{tesseract_download()}.}
 
 \item{HOCR}{if \code{TRUE} return results as HOCR xml instead of plain text}
 
@@ -28,7 +28,7 @@ To use this function you need to tesseract first:\preformatted{  install.package
 }
 
 Best results are obtained if you set the correct language in \link[tesseract:tesseract]{tesseract}.
-To install additional languages see instructions in \link[tesseract:tessdata]{tesseract_download()}.
+To install additional languages see instructions in \link[tesseract:tesseract_download]{tesseract_download()}.
 }
 \examples{
 if(require("tesseract")){

--- a/man/video.Rd
+++ b/man/video.Rd
@@ -15,16 +15,16 @@ image_write_gif(image, path = NULL, delay = 1/10, ...)
 
 \item{path}{filename of the output gif or video. This is also the return value.}
 
-\item{framerate}{frames per second, passed to \link[av:av_encode_video]{av_encode_video}}
+\item{framerate}{frames per second, passed to \link[av:encoding]{av_encode_video}}
 
-\item{...}{additional parameters passed to \link[av:av_encode_video]{av_encode_video} and
+\item{...}{additional parameters passed to \link[av:encoding]{av_encode_video} and
 \link[gifski:gifski]{gifski}.}
 
 \item{delay}{duration of each frame in seconds (inverse of framerate)}
 }
 \description{
 High quality video / gif exporter based on external packages \link[gifski:gifski]{gifski}
-and \link[av:av_encode_video]{av}.
+and \link[av:encoding]{av}.
 }
 \details{
 This requires an image with multiple frames. The GIF exporter accomplishes the same

--- a/man/video.Rd
+++ b/man/video.Rd
@@ -15,16 +15,16 @@ image_write_gif(image, path = NULL, delay = 1/10, ...)
 
 \item{path}{filename of the output gif or video. This is also the return value.}
 
-\item{framerate}{frames per second, passed to \link[av:encoding]{av_encode_video}}
+\item{framerate}{frames per second, passed to \link[av:av_encode_video]{av_encode_video}}
 
-\item{...}{additional parameters passed to \link[av:encoding]{av_encode_video} and
+\item{...}{additional parameters passed to \link[av:av_encode_video]{av_encode_video} and
 \link[gifski:gifski]{gifski}.}
 
 \item{delay}{duration of each frame in seconds (inverse of framerate)}
 }
 \description{
 High quality video / gif exporter based on external packages \link[gifski:gifski]{gifski}
-and \link[av:encoding]{av}.
+and \link[av:av_encode_video]{av}.
 }
 \details{
 This requires an image with multiple frames. The GIF exporter accomplishes the same

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -968,8 +968,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // magick_image_write
-Rcpp::RawVector magick_image_write(XPtrImage input, Rcpp::CharacterVector format, Rcpp::IntegerVector quality, Rcpp::IntegerVector depth, Rcpp::CharacterVector density, Rcpp::CharacterVector comment);
-RcppExport SEXP _magick_magick_image_write(SEXP inputSEXP, SEXP formatSEXP, SEXP qualitySEXP, SEXP depthSEXP, SEXP densitySEXP, SEXP commentSEXP) {
+Rcpp::RawVector magick_image_write(XPtrImage input, Rcpp::CharacterVector format, Rcpp::IntegerVector quality, Rcpp::IntegerVector depth, Rcpp::CharacterVector density, Rcpp::CharacterVector comment, Rcpp::CharacterVector defines);
+RcppExport SEXP _magick_magick_image_write(SEXP inputSEXP, SEXP formatSEXP, SEXP qualitySEXP, SEXP depthSEXP, SEXP densitySEXP, SEXP commentSEXP, SEXP definesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -979,7 +979,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type depth(depthSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type density(densitySEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type comment(commentSEXP);
-    rcpp_result_gen = Rcpp::wrap(magick_image_write(input, format, quality, depth, density, comment));
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type defines(definesSEXP);
+    rcpp_result_gen = Rcpp::wrap(magick_image_write(input, format, quality, depth, density, comment, defines));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1551,7 +1552,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_magick_magick_image_readbin", (DL_FUNC) &_magick_magick_image_readbin, 5},
     {"_magick_magick_image_readpath", (DL_FUNC) &_magick_magick_image_readpath, 5},
     {"_magick_magick_image_read_list", (DL_FUNC) &_magick_magick_image_read_list, 1},
-    {"_magick_magick_image_write", (DL_FUNC) &_magick_magick_image_write, 6},
+    {"_magick_magick_image_write", (DL_FUNC) &_magick_magick_image_write, 7},
     {"_magick_magick_image_write_frame", (DL_FUNC) &_magick_magick_image_write_frame, 3},
     {"_magick_magick_image_write_integer", (DL_FUNC) &_magick_magick_image_write_integer, 1},
     {"_magick_magick_image_display", (DL_FUNC) &_magick_magick_image_display, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -942,7 +942,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // magick_image_readpath
-XPtrImage magick_image_readpath(Rcpp::CharacterVector paths, Rcpp::CharacterVector density, Rcpp::IntegerVector depth, bool strip, Rcpp::CharacterVector defines);
+XPtrImage magick_image_readpath(Rcpp::CharacterVector paths, Rcpp::CharacterVector density, Rcpp::IntegerVector depth, bool strip, Rcpp::List defines);
 RcppExport SEXP _magick_magick_image_readpath(SEXP pathsSEXP, SEXP densitySEXP, SEXP depthSEXP, SEXP stripSEXP, SEXP definesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -951,7 +951,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type density(densitySEXP);
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type depth(depthSEXP);
     Rcpp::traits::input_parameter< bool >::type strip(stripSEXP);
-    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type defines(definesSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type defines(definesSEXP);
     rcpp_result_gen = Rcpp::wrap(magick_image_readpath(paths, density, depth, strip, defines));
     return rcpp_result_gen;
 END_RCPP
@@ -968,7 +968,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // magick_image_write
-Rcpp::RawVector magick_image_write(XPtrImage input, Rcpp::CharacterVector format, Rcpp::IntegerVector quality, Rcpp::IntegerVector depth, Rcpp::CharacterVector density, Rcpp::CharacterVector comment, Rcpp::CharacterVector defines);
+Rcpp::RawVector magick_image_write(XPtrImage input, Rcpp::CharacterVector format, Rcpp::IntegerVector quality, Rcpp::IntegerVector depth, Rcpp::CharacterVector density, Rcpp::CharacterVector comment, Rcpp::List defines);
 RcppExport SEXP _magick_magick_image_write(SEXP inputSEXP, SEXP formatSEXP, SEXP qualitySEXP, SEXP depthSEXP, SEXP densitySEXP, SEXP commentSEXP, SEXP definesSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -979,7 +979,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type depth(depthSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type density(densitySEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type comment(commentSEXP);
-    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type defines(definesSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type defines(definesSEXP);
     rcpp_result_gen = Rcpp::wrap(magick_image_write(input, format, quality, depth, density, comment, defines));
     return rcpp_result_gen;
 END_RCPP


### PR DESCRIPTION
Closes #258.

A few things I'm unsure about:

* Unlike `magick_image_readbin`, which passes `Magick::readImages()` a `Magick::ReadOptions` object, this calls `defineValue()` on each `Magick::Image`. I think this is the right way to do it, but I'm not 100% sure.
* My understanding of the code is that defining the value mutates the `Image` object. However, when I try writing an image with `defines`, and then without it, the second time doesn't seem to keep those defined values. So maybe I'm probably not understanding it correctly.


Example:

```R
x <- image_read("https://jeroen.github.io/images/frink.png")
image_write(x, "frink.png")
image_write(x, "frink-big.png",
  defines = c(
    "png:compression-filter" = "1",
    "png:compression-level" = "0"
  )
)
image_write(x, "frink2.png")

file.info(c("frink.png", "frink-big.png", "frink2.png"))$size
#> [1]  67143 392512  67143
```


Also, this doesn't support defines where the key is defined without a value. The same is true for the current implementation in `image_read`, I believe. Here's an example from http://www.imagemagick.org/script/command-line-options.php#define, which defines two keys without values:

```
magick bilevel.tif -define ps:imagemask eps3:stencil.ps
```
