### PR TITLE
Unrevert y-scale in image_ggplot()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@
   - Windows: new imagemagick should work again with latest GhostScript
   - New function image_distort()
   - image_convert() gains a parameter 'interlace' (#269)
+  - The y-scale in image_ggplot() is no longer inverted, to avoid bugs in ggplot2
 
 2.4.0
   - New functions: image_fx_sequence, image_deskew_angle, image_get_artifacts

--- a/R/ggplot2.R
+++ b/R/ggplot2.R
@@ -33,8 +33,7 @@ image_ggplot <- function(image, interpolate = FALSE) {
   ggplot2::ggplot(data.frame(x = 0, y = 0), ggplot2::aes_string('x', 'y')) +
     ggplot2::geom_blank() +
     ggplot2::theme_void() +
-    ggplot2::scale_y_reverse() +
     ggplot2::coord_fixed(expand = FALSE, xlim = c(0, info$width), ylim = c(0, info$height)) +
-    ggplot2::annotation_raster(image, 0, info$width, -info$height, 0, interpolate = interpolate) +
+    ggplot2::annotation_raster(image, 0, info$width, info$height, 0, interpolate = interpolate) +
     NULL
 }


### PR DESCRIPTION
This avoids the ggplot2 bug in #266 but I'm worried it may break the api.

@cschwem2er do your vignettes of imgrec and facerec that use `image_ggplot()` break with this?