### PR TITLE
add strokewidth parameter to image_annotate

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -497,8 +497,8 @@ magick_image_reducenoise <- function(input, radius) {
     .Call('_magick_magick_image_reducenoise', PACKAGE = 'magick', input, radius)
 }
 
-magick_image_annotate <- function(input, text, gravity, location, rot, size, font, style, weight, kerning, decoration, color, strokecolor, boxcolor) {
-    .Call('_magick_magick_image_annotate', PACKAGE = 'magick', input, text, gravity, location, rot, size, font, style, weight, kerning, decoration, color, strokecolor, boxcolor)
+magick_image_annotate <- function(input, text, gravity, location, rot, size, font, style, weight, kerning, decoration, color, strokecolor, strokewidth, boxcolor) {
+    .Call('_magick_magick_image_annotate', PACKAGE = 'magick', input, text, gravity, location, rot, size, font, style, weight, kerning, decoration, color, strokecolor, strokewidth, boxcolor)
 }
 
 magick_image_compare <- function(input, reference_image, metric, fuzz_percent) {

--- a/R/paint.R
+++ b/R/paint.R
@@ -69,7 +69,7 @@ image_fill <- function(image, color, point = "+1+1", fuzz = 0, refcolor = NULL){
 image_annotate <- function(image, text, gravity = "northwest", location = "+0+0", degrees = 0,
                            size = 10, font = "", style = "normal", weight = 400, kerning = 0,
                            decoration = NULL, color = NULL, strokecolor = NULL,
-                           strokewidth = 1, boxcolor = NULL){
+                           strokewidth = NULL, boxcolor = NULL){
   assert_image(image)
   font <- as.character(font)
   size <- as.integer(size)

--- a/R/paint.R
+++ b/R/paint.R
@@ -50,6 +50,7 @@ image_fill <- function(image, color, point = "+1+1", fuzz = 0, refcolor = NULL){
 #' @param size font-size in pixels
 #' @param strokecolor a [color string](https://www.imagemagick.org/Magick++/Color.html)
 #' adds a stroke (border around the text)
+#' @param strokewidth set the strokewidth of the border around the text
 #' @param boxcolor a [color string](https://www.imagemagick.org/Magick++/Color.html)
 #' for background color that annotation text is rendered on.
 #' @param font string with font family such as `"sans"`, `"mono"`, `"serif"`,
@@ -67,7 +68,8 @@ image_fill <- function(image, color, point = "+1+1", fuzz = 0, refcolor = NULL){
 #' image_annotate(logo, "The quick brown fox", font = "monospace", size = 50)
 image_annotate <- function(image, text, gravity = "northwest", location = "+0+0", degrees = 0,
                            size = 10, font = "", style = "normal", weight = 400, kerning = 0,
-                           decoration = NULL, color = NULL, strokecolor = NULL, boxcolor = NULL){
+                           decoration = NULL, color = NULL, strokecolor = NULL,
+                           strokewidth = 1, boxcolor = NULL){
   assert_image(image)
   font <- as.character(font)
   size <- as.integer(size)
@@ -75,9 +77,10 @@ image_annotate <- function(image, text, gravity = "northwest", location = "+0+0"
   kerning <- as.numeric(kerning)
   color <- as.character(color)
   strokecolor <- as.character(strokecolor)
+  strokewidth <- as.integer(strokewidth)
   boxcolor <- as.character(boxcolor)
   decoration <- as.character(decoration)
   magick_image_annotate(image, text, gravity, location, degrees, size,
                         font, style, weight, kerning, decoration,
-                        color, strokecolor, boxcolor)
+                        color, strokecolor, strokewidth, boxcolor)
 }

--- a/man/painting.Rd
+++ b/man/painting.Rd
@@ -22,7 +22,7 @@ image_annotate(
   decoration = NULL,
   color = NULL,
   strokecolor = NULL,
-  strokewidth = 1,
+  strokewidth = NULL,
   boxcolor = NULL
 )
 }

--- a/man/painting.Rd
+++ b/man/painting.Rd
@@ -22,6 +22,7 @@ image_annotate(
   decoration = NULL,
   color = NULL,
   strokecolor = NULL,
+  strokewidth = 1,
   boxcolor = NULL
 )
 }
@@ -67,6 +68,8 @@ value from \link{gravity_types}.}
 
 \item{strokecolor}{a \href{https://www.imagemagick.org/Magick++/Color.html}{color string}
 adds a stroke (border around the text)}
+
+\item{strokewidth}{set the strokewidth of the border around the text}
 
 \item{boxcolor}{a \href{https://www.imagemagick.org/Magick++/Color.html}{color string}
 for background color that annotation text is rendered on.}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1546,7 +1546,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // magick_image_annotate
-XPtrImage magick_image_annotate(XPtrImage input, Rcpp::CharacterVector text, const char * gravity, const char * location, double rot, double size, const char * font, const char * style, double weight, double kerning, Rcpp::CharacterVector decoration, Rcpp::CharacterVector color, Rcpp::CharacterVector strokecolor, double strokewidth, Rcpp::CharacterVector boxcolor);
+XPtrImage magick_image_annotate(XPtrImage input, Rcpp::CharacterVector text, const char * gravity, const char * location, double rot, double size, const char * font, const char * style, double weight, double kerning, Rcpp::CharacterVector decoration, Rcpp::CharacterVector color, Rcpp::CharacterVector strokecolor, Rcpp::IntegerVector strokewidth, Rcpp::CharacterVector boxcolor);
 RcppExport SEXP _magick_magick_image_annotate(SEXP inputSEXP, SEXP textSEXP, SEXP gravitySEXP, SEXP locationSEXP, SEXP rotSEXP, SEXP sizeSEXP, SEXP fontSEXP, SEXP styleSEXP, SEXP weightSEXP, SEXP kerningSEXP, SEXP decorationSEXP, SEXP colorSEXP, SEXP strokecolorSEXP, SEXP strokewidthSEXP, SEXP boxcolorSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
@@ -1564,7 +1564,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type decoration(decorationSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type color(colorSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type strokecolor(strokecolorSEXP);
-    Rcpp::traits::input_parameter< double >::type strokewidth(strokewidthSEXP);
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type strokewidth(strokewidthSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type boxcolor(boxcolorSEXP);
     rcpp_result_gen = Rcpp::wrap(magick_image_annotate(input, text, gravity, location, rot, size, font, style, weight, kerning, decoration, color, strokecolor, strokewidth, boxcolor));
     return rcpp_result_gen;

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1546,8 +1546,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // magick_image_annotate
-XPtrImage magick_image_annotate(XPtrImage input, Rcpp::CharacterVector text, const char * gravity, const char * location, double rot, double size, const char * font, const char * style, double weight, double kerning, Rcpp::CharacterVector decoration, Rcpp::CharacterVector color, Rcpp::CharacterVector strokecolor, Rcpp::CharacterVector boxcolor);
-RcppExport SEXP _magick_magick_image_annotate(SEXP inputSEXP, SEXP textSEXP, SEXP gravitySEXP, SEXP locationSEXP, SEXP rotSEXP, SEXP sizeSEXP, SEXP fontSEXP, SEXP styleSEXP, SEXP weightSEXP, SEXP kerningSEXP, SEXP decorationSEXP, SEXP colorSEXP, SEXP strokecolorSEXP, SEXP boxcolorSEXP) {
+XPtrImage magick_image_annotate(XPtrImage input, Rcpp::CharacterVector text, const char * gravity, const char * location, double rot, double size, const char * font, const char * style, double weight, double kerning, Rcpp::CharacterVector decoration, Rcpp::CharacterVector color, Rcpp::CharacterVector strokecolor, double strokewidth, Rcpp::CharacterVector boxcolor);
+RcppExport SEXP _magick_magick_image_annotate(SEXP inputSEXP, SEXP textSEXP, SEXP gravitySEXP, SEXP locationSEXP, SEXP rotSEXP, SEXP sizeSEXP, SEXP fontSEXP, SEXP styleSEXP, SEXP weightSEXP, SEXP kerningSEXP, SEXP decorationSEXP, SEXP colorSEXP, SEXP strokecolorSEXP, SEXP strokewidthSEXP, SEXP boxcolorSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -1564,8 +1564,9 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type decoration(decorationSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type color(colorSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type strokecolor(strokecolorSEXP);
+    Rcpp::traits::input_parameter< double >::type strokewidth(strokewidthSEXP);
     Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type boxcolor(boxcolorSEXP);
-    rcpp_result_gen = Rcpp::wrap(magick_image_annotate(input, text, gravity, location, rot, size, font, style, weight, kerning, decoration, color, strokecolor, boxcolor));
+    rcpp_result_gen = Rcpp::wrap(magick_image_annotate(input, text, gravity, location, rot, size, font, style, weight, kerning, decoration, color, strokecolor, strokewidth, boxcolor));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1723,7 +1724,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_magick_magick_image_orient", (DL_FUNC) &_magick_magick_image_orient, 2},
     {"_magick_magick_image_despeckle", (DL_FUNC) &_magick_magick_image_despeckle, 2},
     {"_magick_magick_image_reducenoise", (DL_FUNC) &_magick_magick_image_reducenoise, 2},
-    {"_magick_magick_image_annotate", (DL_FUNC) &_magick_magick_image_annotate, 14},
+    {"_magick_magick_image_annotate", (DL_FUNC) &_magick_magick_image_annotate, 15},
     {"_magick_magick_image_compare", (DL_FUNC) &_magick_magick_image_compare, 4},
     {"_magick_magick_image_distort", (DL_FUNC) &_magick_magick_image_distort, 4},
     {NULL, NULL, 0}

--- a/src/transformations.cpp
+++ b/src/transformations.cpp
@@ -340,7 +340,7 @@ XPtrImage magick_image_annotate( XPtrImage input, Rcpp::CharacterVector text, co
                                  const char * location, double rot, double size, const char * font,
                                  const char * style, double weight, double kerning,
                                  Rcpp::CharacterVector decoration, Rcpp::CharacterVector color,
-                                 Rcpp::CharacterVector strokecolor, double strokewidth,
+                                 Rcpp::CharacterVector strokecolor, Rcpp::IntegerVector strokewidth,
                                  Rcpp::CharacterVector boxcolor){
   XPtrImage output = copy(input);
   typedef std::container<Magick::Drawable> drawlist;
@@ -352,8 +352,8 @@ XPtrImage magick_image_annotate( XPtrImage input, Rcpp::CharacterVector text, co
   draw.push_back(Magick::DrawableTextAntialias(true));
   if(strokecolor.size())
     draw.push_back(Magick::DrawableStrokeColor(Color(strokecolor[0])));
-  if(strokewidth != 0)
-    draw.push_back(Magick::DrawableStrokeWidth(strokewidth));
+  if(strokewidth.size())
+    draw.push_back(Magick::DrawableStrokeWidth(strokewidth[0]));
   if(color.size())
     draw.push_back(Magick::DrawableFillColor(Color(color[0])));
   if(boxcolor.size())

--- a/src/transformations.cpp
+++ b/src/transformations.cpp
@@ -340,7 +340,8 @@ XPtrImage magick_image_annotate( XPtrImage input, Rcpp::CharacterVector text, co
                                  const char * location, double rot, double size, const char * font,
                                  const char * style, double weight, double kerning,
                                  Rcpp::CharacterVector decoration, Rcpp::CharacterVector color,
-                                 Rcpp::CharacterVector strokecolor, Rcpp::CharacterVector boxcolor){
+                                 Rcpp::CharacterVector strokecolor, double strokewidth,
+                                 Rcpp::CharacterVector boxcolor){
   XPtrImage output = copy(input);
   typedef std::container<Magick::Drawable> drawlist;
   Magick::Geometry pos(location);
@@ -351,6 +352,8 @@ XPtrImage magick_image_annotate( XPtrImage input, Rcpp::CharacterVector text, co
   draw.push_back(Magick::DrawableTextAntialias(true));
   if(strokecolor.size())
     draw.push_back(Magick::DrawableStrokeColor(Color(strokecolor[0])));
+  if(strokewidth != 0)
+    draw.push_back(Magick::DrawableStrokeWidth(strokewidth));
   if(color.size())
     draw.push_back(Magick::DrawableFillColor(Color(color[0])));
   if(boxcolor.size())


### PR DESCRIPTION
Adding missing `strokewidth` parameter to `image_annotate`. 

```
library(magick)

img <- image_blank(480, 320)

image_annotate(img, "Strokewidth Test", size = 60, strokecolor = "red", strokewidth = 1)
image_annotate(img, "Strokewidth Test", size = 60, strokecolor = "red", strokewidth = 2)
```